### PR TITLE
Add no-object-mutation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In addition to immutable rules this project also contains a few rules for enforc
   * [readonly-keyword](#readonly-keyword)
   * [readonly-array](#readonly-array)
   * [no-let](#no-let)
+  * [no-object-mutation](#no-object-mutation)
 * [Functional style rules](#functional-style-rules)
   * [no-this](#no-this-no-class)
   * [no-class](#no-this-no-class)
@@ -163,6 +164,17 @@ const SearchResults =
     }</ul>;
 ```
 
+### no-object-mutation
+This rule prohibits syntax that mutates existing objects via assignment to or deletion of their properties. While requiring the `readonly` modifier forces declared types to be immutable, it won't stop assignment into or modification of untyped objects or external types declared under different rules. Forbidding forms like `a.b = 'c'` is one way to plug this hole. Inspired by the no-mutation rule of [eslint-plugin-immutable](https://github.com/jhusain/eslint-plugin-immutable).
+
+```typescript
+const x = {a: 1};
+
+x.foo = 'bar'; // <- Modifying properties of existing object not allowed.
+x.a += 1; // <- Modifying properties of existing object not allowed.
+delete x.a; // <- Modifying properties of existing object not allowed.
+```
+
 ## Functional style rules
 
 ### no-this, no-class
@@ -284,6 +296,7 @@ Here's a sample TSLint configuration file (tslint.json) that activates all the r
     "readonly-keyword": true,
     "readonly-array": true,
     "no-let": true,
+    "no-object-mutation": true,
 
     // Functional style rules
     "no-this": true,

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -1,0 +1,54 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static FAILURE_STRING = "Modifying properties of existing object not allowed.";
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const noObjectMutationWalker = new NoObjectMutationWalker(sourceFile, this.getOptions());
+    return this.applyWithWalker(noObjectMutationWalker);
+  }
+}
+
+const forbidObjPropOnLeftSideOf: ReadonlyArray<ts.SyntaxKind> = [
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.LessThanLessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken
+];
+
+class NoObjectMutationWalker extends Lint.RuleWalker {
+
+  public visitNode(node: ts.Node): void {
+    // No assignment with object.property on the left
+    if (node && node.kind === ts.SyntaxKind.BinaryExpression) {
+      const binExp = node as ts.BinaryExpression;
+      if (binExp.operatorToken &&
+          binExp.left.kind === ts.SyntaxKind.PropertyAccessExpression &&
+          forbidObjPropOnLeftSideOf.some(k => k === binExp.operatorToken.kind)) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      }
+    }
+
+    // No deleting object properties
+    if (node && node.kind === ts.SyntaxKind.DeleteExpression) {
+      const delExp = node as ts.DeleteExpression;
+      if (delExp.expression &&
+          delExp.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      }
+    }
+
+    super.visitNode(node);
+  }
+
+}

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -10,6 +10,11 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
+const objPropAccessors: ReadonlyArray<ts.SyntaxKind> = [
+  ts.SyntaxKind.ElementAccessExpression,
+  ts.SyntaxKind.PropertyAccessExpression
+];
+
 const forbidObjPropOnLeftSideOf: ReadonlyArray<ts.SyntaxKind> = [
   ts.SyntaxKind.EqualsToken,
   ts.SyntaxKind.PlusEqualsToken,
@@ -26,14 +31,18 @@ const forbidObjPropOnLeftSideOf: ReadonlyArray<ts.SyntaxKind> = [
   ts.SyntaxKind.CaretEqualsToken
 ];
 
+const forbidUnaryOps: ReadonlyArray<ts.SyntaxKind> = [
+  ts.SyntaxKind.PlusPlusToken,
+  ts.SyntaxKind.MinusMinusToken
+];
+
 class NoObjectMutationWalker extends Lint.RuleWalker {
 
   public visitNode(node: ts.Node): void {
     // No assignment with object.property on the left
     if (node && node.kind === ts.SyntaxKind.BinaryExpression) {
       const binExp = node as ts.BinaryExpression;
-      if (binExp.operatorToken &&
-          binExp.left.kind === ts.SyntaxKind.PropertyAccessExpression &&
+      if (objPropAccessors.some(k => k === binExp.left.kind) &&
           forbidObjPropOnLeftSideOf.some(k => k === binExp.operatorToken.kind)) {
         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
       }
@@ -42,8 +51,25 @@ class NoObjectMutationWalker extends Lint.RuleWalker {
     // No deleting object properties
     if (node && node.kind === ts.SyntaxKind.DeleteExpression) {
       const delExp = node as ts.DeleteExpression;
-      if (delExp.expression &&
-          delExp.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+      if (objPropAccessors.some(k => k === delExp.expression.kind)) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      }
+    }
+
+    // No prefix inc/dec
+    if (node && node.kind === ts.SyntaxKind.PrefixUnaryExpression) {
+      const preExp = node as ts.PrefixUnaryExpression;
+      if (objPropAccessors.some(k => k === preExp.operand.kind) &&
+          forbidUnaryOps.some(o => o === preExp.operator)) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      }
+    }
+
+    // No postfix inc/dec
+    if (node && node.kind === ts.SyntaxKind.PostfixUnaryExpression) {
+      const postExp = node as ts.PostfixUnaryExpression;
+      if (objPropAccessors.some(k => k === postExp.operand.kind) &&
+         forbidUnaryOps.some(o => o === postExp.operator)) {
         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
       }
     }

--- a/test/rules/no-object-mutation/default/test.ts.lint
+++ b/test/rules/no-object-mutation/default/test.ts.lint
@@ -1,0 +1,45 @@
+const x = {a: 1};
+
+x.foo = 'bar';
+~~~~~~~~~~~~~ [failure]
+
+x.a += 1;
+~~~~~~~~ [failure]
+
+x.a -= 1;
+~~~~~~~~ [failure]
+
+x.a *= 1;
+~~~~~~~~ [failure]
+
+x.a **= 1;
+~~~~~~~~~ [failure]
+
+x.a /= 1;
+~~~~~~~~ [failure]
+
+x.a %= 1;
+~~~~~~~~ [failure]
+
+x.a <<= 1;
+~~~~~~~~~ [failure]
+
+x.a >>= 1;
+~~~~~~~~~ [failure]
+
+x.a >>>= 1;
+~~~~~~~~~~ [failure]
+
+x.a &= 1;
+~~~~~~~~ [failure]
+
+x.a |= 1;
+~~~~~~~~ [failure]
+
+x.a ^= 1;
+~~~~~~~~ [failure]
+
+delete x.a;
+~~~~~~~~~~ [failure]
+
+[failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/default/test.ts.lint
+++ b/test/rules/no-object-mutation/default/test.ts.lint
@@ -1,7 +1,12 @@
 const x = {a: 1};
 
+// Disallowed object mutation patterns
+
 x.foo = 'bar';
 ~~~~~~~~~~~~~ [failure]
+
+x['foo'] = 'bar';
+~~~~~~~~~~~~~~~~ [failure]
 
 x.a += 1;
 ~~~~~~~~ [failure]
@@ -41,5 +46,35 @@ x.a ^= 1;
 
 delete x.a;
 ~~~~~~~~~~ [failure]
+
+delete x['a'];
+~~~~~~~~~~~~~ [failure]
+
+x.a++;
+~~~~~ [failure]
+
+x.a--;
+~~~~~ [failure]
+
+++x.a;
+~~~~~ [failure]
+
+--x.a;
+~~~~~ [failure]
+
+if (x.a = 2) {}
+    ~~~~~~~ [failure]
+
+if (x.a++) {}
+    ~~~~~ [failure]
+
+
+// Non-mutating patterns that we shouldn't catch
+
+const y = x.a;
+const z = x['a'];
+if (x.a && y.a) {}
+const w = ~x.a;
+if (!x.a) {}
 
 [failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/default/tslint.json
+++ b/test/rules/no-object-mutation/default/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "no-object-mutation": true
+  }
+}

--- a/tslint-immutable.json
+++ b/tslint-immutable.json
@@ -7,6 +7,7 @@
     "no-this": false,
     "no-class": false,
     "no-mixed-interface": false,
-    "no-expression-statement": false
+    "no-expression-statement": false,
+    "no-object-mutation": false
   }
 }


### PR DESCRIPTION
New rule: no-object-mutation.
Prevents property modification of forms like:
```typescript
const x = {a: 1};

x.foo = 'bar'; // <- Modifying properties of existing object not allowed.
x.a += 1; // <- Modifying properties of existing object not allowed.
delete x.a; // <- Modifying properties of existing object not allowed.
```

For motivation, see issue #36. Also partially addresses #3 but only for property deletion.
