### PR TITLE
Add ignore-prefix option to no-object-mutation rule

### DIFF
--- a/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
+++ b/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
@@ -1,0 +1,33 @@
+const x = {a: 1};
+const mutableY = {a: 1};
+
+// Disallowed object mutation patterns
+
+x.foo = 'bar';
+~~~~~~~~~~~~~ [failure]
+
+x['foo'] = 'bar';
+~~~~~~~~~~~~~~~~ [failure]
+
+delete x.foo;
+~~~~~~~~~~~~ [failure]
+
+x.a++;
+~~~~~ [failure]
+
+++x.a;
+~~~~~ [failure]
+
+// Allowed prefix
+
+mutableY.foo = 'bar';
+
+mutableY['foo'] = 'bar';
+
+delete mutableY.foo;
+
+mutableY.a++;
+
+++mutableY.a;
+
+[failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/ignore-prefix/tslint.json
+++ b/test/rules/no-object-mutation/ignore-prefix/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "no-object-mutation": [true, { "ignore-prefix": "mutable" }]
+  }
+}


### PR DESCRIPTION
Added an option for ignoring object mutation by prefix. Partially addresses #43.

Feels like the option parsing and isIgnored checks want a shared module like readonly-shared to avoid duplication, but made them their own thing for now to avoid affecting other rules.
