### PR TITLE
Display errors for class expressions

### DIFF
--- a/src/noClassRule.ts
+++ b/src/noClassRule.ts
@@ -19,7 +19,7 @@ function checkNode(
   _ctx: Lint.WalkContext<Options>
 ): CheckNodeResult {
   return node &&
-    (node.kind === ts.SyntaxKind.ClassKeyword ||
+    (node.kind === ts.SyntaxKind.ClassExpression ||
       node.kind === ts.SyntaxKind.ClassDeclaration)
     ? { invalidNodes: [createInvalidNode(node)] }
     : {

--- a/test/rules/no-class/default/test.ts.lint
+++ b/test/rules/no-class/default/test.ts.lint
@@ -3,4 +3,7 @@ var x = 0;
 class Foo {}
 ~~~~~~~~~~~~ [failure]
 
+const klass = class {}
+              ~~~~~~~~ [failure]
+
 [failure]: Unexpected class, use functions not classes.


### PR DESCRIPTION
The current behavior of the `no-class` rule is to display errors for class declarations but not for class expressions. This alters the rule to display errors for both cases, fixing issue #65. I can't think of a instance of a user wanting one but not the other, so I didn't introduce a option for specifying so.