### PR TITLE
Improve `no-array-mutation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ No
 #### Options
 
 * [ignore-prefix](#using-the-ignore-prefix-option)
+* [ignore-mutation-following-accessor](#using-the-ignore-mutation-following-accessor-option-with-no-array-mutation)
 
 #### Example config
 
@@ -255,6 +256,10 @@ No
 
 ```javascript
 "no-array-mutation": [true, {"ignore-prefix": "mutable"}]
+```
+
+```javascript
+"no-array-mutation": [true, "ignore-mutation-following-accessor"]
 ```
 
 ### no-object-mutation
@@ -480,6 +485,16 @@ const doSomething(arg:string) => {
   }
   return `Hello ${arg}`;
 }
+```
+
+### Using the `ignore-mutation-following-accessor` option with `no-array-mutation`
+
+This option allows for the use of array mutating methods to be chained to an array accessor method (such as `slice` or `concat`).
+
+For example, an array can be immutably sorted with a single line like so:
+
+```typescript
+const sorted = ["foo", "bar"].slice().sort((a, b) => a.localeCompare(b)); // This is OK with ignore-mutation-following-accessor
 ```
 
 ## Recommended built-in rules

--- a/src/noArrayMutationRule.ts
+++ b/src/noArrayMutationRule.ts
@@ -44,7 +44,12 @@ const forbidUnaryOps: ReadonlyArray<ts.SyntaxKind> = [
   ts.SyntaxKind.MinusMinusToken
 ];
 
-const forbidMethods: ReadonlyArray<string> = [
+/**
+ * Methods that mutate an array.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype#Methods#Mutator_methods
+ */
+const mutatorMethods: ReadonlyArray<string> = [
   "copyWithin",
   "fill",
   "pop",
@@ -54,6 +59,17 @@ const forbidMethods: ReadonlyArray<string> = [
   "sort",
   "splice",
   "unshift"
+];
+
+/**
+ * Methods that return a new array without mutating the original.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype#Methods#Accessor_methods
+ */
+const accessorMethods: ReadonlyArray<string> = [
+  "concat",
+  "slice",
+  "toSource" // TODO: This is a non standardized method, should it me including?
 ];
 
 function isArrayType(type: ts.Type): boolean {
@@ -221,7 +237,7 @@ function checkCallExpression(
   if (ts.SyntaxKind.PropertyAccessExpression === callExp.expression.kind) {
     const propAccExp = callExp.expression as ts.PropertyAccessExpression;
     if (
-      forbidMethods.some(m => m === propAccExp.name.text) &&
+      mutatorMethods.some(m => m === propAccExp.name.text) &&
       !Ignore.isIgnoredPrefix(
         callExp.getText(node.getSourceFile()),
         ctx.options.ignorePrefix

--- a/src/shared/ignore.ts
+++ b/src/shared/ignore.ts
@@ -9,7 +9,8 @@ import * as CheckNode from "./check-node";
 export type Options = IgnoreLocalOption &
   IgnorePrefixOption &
   IgnoreClassOption &
-  IgnoreInterfaceOption;
+  IgnoreInterfaceOption &
+  IgnoreMutationFollowingAccessorOption;
 
 export interface IgnoreLocalOption {
   readonly ignoreLocal?: boolean;
@@ -25,6 +26,10 @@ export interface IgnoreClassOption {
 
 export interface IgnoreInterfaceOption {
   readonly ignoreInterface?: boolean;
+}
+
+export interface IgnoreMutationFollowingAccessorOption {
+  readonly ignoreMutationFollowingAccessor?: boolean;
 }
 
 export function checkNodeWithIgnore(

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -36,5 +36,11 @@ function upFirst(word: string): string {
 
 function camelize(text: string): string {
   let words = text.split(/[-_]/g);
-  return words[0].toLowerCase() + words.slice(1).map(upFirst);
+  return (
+    words[0].toLowerCase() +
+    words
+      .slice(1)
+      .map(upFirst)
+      .join("")
+  );
 }

--- a/test/rules/no-array-mutation/default/test.ts.lint
+++ b/test/rules/no-array-mutation/default/test.ts.lint
@@ -140,6 +140,64 @@ x.slice(1, 2);
 x.toString();
 x.toLocaleString("en", {timeZone: "UTC"});
 
+// Disallowed array mutation methods to be chained to array accessor methods without the setting being set.
+
+x.slice().copyWithin(0, 1, 2);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().fill(3);
+~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().pop();
+~~~~~~~~~~~~~~~ [failure]
+
+x.slice().push(3);
+~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().reverse();
+~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().shift();
+~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().sort();
+~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().splice(0, 1, 9);
+~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.slice().unshift(6);
+~~~~~~~~~~~~~~~~~~~~ [failure]
+
+
+
+x.concat([1, 2, 3]).copyWithin(0, 1, 2);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).fill(3);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).pop();
+~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).push(3);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).reverse();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).shift();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).sort();
+~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).splice(0, 1, 9);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.concat([1, 2, 3]).unshift(6);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
 // Allow other functions and methods
 u();
 v.y();

--- a/test/rules/no-array-mutation/ignore-mutation-following-accessor/test.ts.lint
+++ b/test/rules/no-array-mutation/ignore-mutation-following-accessor/test.ts.lint
@@ -1,0 +1,75 @@
+const x = [0, 1, 2];
+const y = [x];
+
+// Allowed array mutation methods to be chained to array accessor methods.
+
+x.slice().copyWithin(0, 1, 2);
+x.slice().fill(3);
+x.slice().pop();
+x.slice().push(3);
+x.slice().reverse();
+x.slice().shift();
+x.slice().sort();
+x.slice().splice(0, 1, 9);
+x.slice().unshift(6);
+
+x.concat([1, 2, 3]).copyWithin(0, 1, 2);
+x.concat([1, 2, 3]).fill(3);
+x.concat([1, 2, 3]).pop();
+x.concat([1, 2, 3]).push(3);
+x.concat([1, 2, 3]).reverse();
+x.concat([1, 2, 3]).shift();
+x.concat([1, 2, 3]).sort();
+x.concat([1, 2, 3]).splice(0, 1, 9);
+x.concat([1, 2, 3]).unshift(6);
+
+y[0].slice().copyWithin(0, 1, 2);
+y[0].slice().fill(3);
+y[0].slice().pop();
+y[0].slice().push(3);
+y[0].slice().reverse();
+y[0].slice().shift();
+y[0].slice().sort();
+y[0].slice().splice(0, 1, 9);
+y[0].slice().unshift(6);
+
+y[0].concat([1, 2, 3]).copyWithin(0, 1, 2);
+y[0].concat([1, 2, 3]).fill(3);
+y[0].concat([1, 2, 3]).pop();
+y[0].concat([1, 2, 3]).push(3);
+y[0].concat([1, 2, 3]).reverse();
+y[0].concat([1, 2, 3]).shift();
+y[0].concat([1, 2, 3]).sort();
+y[0].concat([1, 2, 3]).splice(0, 1, 9);
+y[0].concat([1, 2, 3]).unshift(6);
+
+// Disallowed array mutation methods
+
+x.copyWithin(0, 1, 2);
+~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+x.fill(3);
+~~~~~~~~~ [failure]
+
+x.pop();
+~~~~~~~ [failure]
+
+x.push(3);
+~~~~~~~~~ [failure]
+
+x.reverse();
+~~~~~~~~~~~ [failure]
+
+x.shift();
+~~~~~~~~~ [failure]
+
+x.sort();
+~~~~~~~~ [failure]
+
+x.splice(0, 1, 9);
+~~~~~~~~~~~~~~~~~ [failure]
+
+x.unshift(6);
+~~~~~~~~~~~~ [failure]
+
+[failure]: Mutating an array is not allowed.

--- a/test/rules/no-array-mutation/ignore-mutation-following-accessor/tsconfig.json
+++ b/test/rules/no-array-mutation/ignore-mutation-following-accessor/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    // Coding style
+    "forceConsistentCasingInFileNames": true,
+    "newLine": "LF",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "lib": ["es2015", "dom"]
+  }
+}

--- a/test/rules/no-array-mutation/ignore-mutation-following-accessor/tslint.json
+++ b/test/rules/no-array-mutation/ignore-mutation-following-accessor/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "no-array-mutation": [true, "ignore-mutation-following-accessor"]
+  }
+}


### PR DESCRIPTION
Fixes: #88

Added option `ignore-mutation-following-accessor` that allows for mutating methods to be using directly after an accessor method in a chain.

For example:

```ts
const sorted = ["foo", "bar"].slice().sort((a, b) => a.localeCompare(b));
```