### PR TITLE
Add support for ignoring rest parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Yes
 
 #### Options
 
-* [ignore-local](#using-the-ignore-local-option)
-* [ignore-prefix](#using-the-ignore-prefix-option)
+- [ignore-local](#using-the-ignore-local-option)
+- [ignore-prefix](#using-the-ignore-prefix-option)
+- [ignore-rest-parameters](#using-the-ignore-rest-parameters)
 
 #### Example config
 
@@ -481,6 +482,9 @@ Doesn't check for `readonly` in classes.
 ### Using the `ignore-interface` option
 
 Doesn't check for `readonly` in interfaces.
+
+### Using the `ignore-rest-parameters` option
+Doesn't check for `ReadonlyArray` for function rest parameters.
 
 ### Using the `ignore-prefix` option
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "rimraf rules && yarn compile",
     "lint": "tslint './src/**/*.ts{,x}'",
     "test": "tslint --test test/rules/**/*",
-    "test:work": "yarn build && tslint --test test/rules/no-try/**/*",
+    "test:work": "yarn build && tslint --test test/rules/readonly-array/*",
     "verify": "yarn build && yarn lint && yarn coverage",
     "coverage": "rimraf coverage .nyc_output && nyc yarn test",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",

--- a/src/readonlyArrayRule.ts
+++ b/src/readonlyArrayRule.ts
@@ -8,7 +8,9 @@ import {
   createCheckNodeRule
 } from "./shared/check-node";
 
-type Options = Ignore.IgnoreLocalOption & Ignore.IgnorePrefixOption;
+type Options = Ignore.IgnoreLocalOption &
+  Ignore.IgnorePrefixOption &
+  Ignore.IgnoreRestParametersOption;
 
 // tslint:disable-next-line:variable-name
 export const Rule = createCheckNodeRule(
@@ -41,6 +43,16 @@ function checkArrayType(
     ) {
       return [];
     }
+
+    if (
+      ctx.options.ignoreRestParameters &&
+      node.parent &&
+      node.parent.kind === ts.SyntaxKind.Parameter &&
+      (node.parent as ts.ParameterDeclaration).dotDotDotToken
+    ) {
+      return [];
+    }
+
     return [
       createInvalidNode(node, [
         new Lint.Replacement(

--- a/src/shared/ignore.ts
+++ b/src/shared/ignore.ts
@@ -8,6 +8,7 @@ import * as CheckNode from "./check-node";
 
 export type Options = IgnoreLocalOption &
   IgnorePrefixOption &
+  IgnoreRestParametersOption &
   IgnoreClassOption &
   IgnoreInterfaceOption &
   IgnoreMutationFollowingAccessorOption;
@@ -18,6 +19,10 @@ export interface IgnoreLocalOption {
 
 export interface IgnorePrefixOption {
   readonly ignorePrefix?: string | Array<string> | undefined;
+}
+
+export interface IgnoreRestParametersOption {
+  readonly ignoreRestParameters?: boolean;
 }
 
 export interface IgnoreClassOption {

--- a/test/rules/readonly-array/default/function.ts.lint
+++ b/test/rules/readonly-array/default/function.ts.lint
@@ -1,0 +1,6 @@
+// -- Function spread arguments
+
+function foo(...numbers: number[]) {
+                         ~~~~~~~~    [Only ReadonlyArray allowed.]
+}
+

--- a/test/rules/readonly-array/ignore-rest-parameters/function.ts.lint
+++ b/test/rules/readonly-array/ignore-rest-parameters/function.ts.lint
@@ -1,0 +1,4 @@
+// -- Function spread arguments
+
+function foo(...numbers: number[]) {
+}

--- a/test/rules/readonly-array/ignore-rest-parameters/interface.ts.fix
+++ b/test/rules/readonly-array/ignore-rest-parameters/interface.ts.fix
@@ -1,0 +1,1 @@
+../default/interface.ts.fix

--- a/test/rules/readonly-array/ignore-rest-parameters/interface.ts.lint
+++ b/test/rules/readonly-array/ignore-rest-parameters/interface.ts.lint
@@ -1,0 +1,1 @@
+../default/interface.ts.lint

--- a/test/rules/readonly-array/ignore-rest-parameters/tslint.json
+++ b/test/rules/readonly-array/ignore-rest-parameters/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "readonly-array": [true, "ignore-rest-parameters"]
+  }
+}

--- a/test/rules/readonly-array/ignore-rest-parameters/type-literal.ts.fix
+++ b/test/rules/readonly-array/ignore-rest-parameters/type-literal.ts.fix
@@ -1,0 +1,1 @@
+../default/type-literal.ts.fix

--- a/test/rules/readonly-array/ignore-rest-parameters/type-literal.ts.lint
+++ b/test/rules/readonly-array/ignore-rest-parameters/type-literal.ts.lint
@@ -1,0 +1,1 @@
+../default/type-literal.ts.lint

--- a/test/rules/readonly-array/ignore-rest-parameters/type.ts.fix
+++ b/test/rules/readonly-array/ignore-rest-parameters/type.ts.fix
@@ -1,0 +1,1 @@
+../default/type.ts.fix

--- a/test/rules/readonly-array/ignore-rest-parameters/type.ts.lint
+++ b/test/rules/readonly-array/ignore-rest-parameters/type.ts.lint
@@ -1,0 +1,1 @@
+../default/type.ts.lint

--- a/test/rules/readonly-array/ignore-rest-parameters/variable.ts.fix
+++ b/test/rules/readonly-array/ignore-rest-parameters/variable.ts.fix
@@ -1,0 +1,1 @@
+../default/variable.ts.fix

--- a/test/rules/readonly-array/ignore-rest-parameters/variable.ts.lint
+++ b/test/rules/readonly-array/ignore-rest-parameters/variable.ts.lint
@@ -1,0 +1,1 @@
+../default/variable.ts.lint


### PR DESCRIPTION
This fixes #73 while we wait for TypeScript to implement a proper fix.

This creates new new unit tests to check rest parameters (with the `default` option and with the new option) and then reuses the existing `default` tests to unsure that the new option doesn't break any of those.