### PR TITLE
Added `ignore-return-type` option for the `readonly-array` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Yes
 - [ignore-local](#using-the-ignore-local-option)
 - [ignore-prefix](#using-the-ignore-prefix-option)
 - [ignore-rest-parameters](#using-the-ignore-rest-parameters)
+- [ignore-return-type](#using-the-ignore-return-type-option)
 
 #### Example config
 
@@ -485,6 +486,10 @@ Doesn't check for `readonly` in interfaces.
 
 ### Using the `ignore-rest-parameters` option
 Doesn't check for `ReadonlyArray` for function rest parameters.
+
+### Using the `ignore-return-type` option
+
+Doesn't check the return type of functions.
 
 ### Using the `ignore-prefix` option
 

--- a/src/readonlyArrayRule.ts
+++ b/src/readonlyArrayRule.ts
@@ -10,7 +10,8 @@ import {
 
 type Options = Ignore.IgnoreLocalOption &
   Ignore.IgnorePrefixOption &
-  Ignore.IgnoreRestParametersOption;
+  Ignore.IgnoreRestParametersOption &
+  Ignore.IgnoreReturnType;
 
 // tslint:disable-next-line:variable-name
 export const Rule = createCheckNodeRule(
@@ -53,6 +54,10 @@ function checkArrayType(
       return [];
     }
 
+    if (ctx.options.ignoreReturnType && checkIsReturnType(node)) {
+      return [];
+    }
+
     return [
       createInvalidNode(node, [
         new Lint.Replacement(
@@ -82,6 +87,11 @@ function checkTypeReference(
     ) {
       return [];
     }
+
+    if (ctx.options.ignoreReturnType && checkIsReturnType(node)) {
+      return [];
+    }
+
     return [
       createInvalidNode(node, [
         new Lint.Replacement(node.getStart(ctx.sourceFile), 0, "Readonly")
@@ -140,4 +150,18 @@ function checkVariableOrParameterImplicitType(
     }
   }
   return [];
+}
+
+function checkIsReturnType(node: ts.Node): boolean {
+  return Boolean(
+    node.parent !== undefined &&
+      (node.parent.kind === ts.SyntaxKind.FunctionDeclaration ||
+        node.parent.kind === ts.SyntaxKind.FunctionExpression ||
+        node.parent.kind === ts.SyntaxKind.ArrowFunction) &&
+      node ===
+        (node.parent as
+          | ts.FunctionDeclaration
+          | ts.FunctionExpression
+          | ts.ArrowFunction).type
+  );
 }

--- a/src/shared/ignore.ts
+++ b/src/shared/ignore.ts
@@ -25,6 +25,10 @@ export interface IgnoreRestParametersOption {
   readonly ignoreRestParameters?: boolean;
 }
 
+export interface IgnoreReturnType {
+  readonly ignoreReturnType?: boolean;
+}
+
 export interface IgnoreClassOption {
   readonly ignoreClass?: boolean;
 }

--- a/test/rules/readonly-array/ignore-return-type/function.ts.lint
+++ b/test/rules/readonly-array/ignore-return-type/function.ts.lint
@@ -1,0 +1,72 @@
+// Function Declarations
+
+function foo(...numbers: ReadOnlyArray<number>): ReadOnlyArray<number> {
+}
+
+function foo(...numbers: Array<number>): ReadOnlyArray<number> {
+                         ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+function foo(...numbers: ReadOnlyArray<number>): Array<number> {
+}
+
+function foo(...numbers: Array<number>): Array<number> {
+                         ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+function foo(...numbers: ReadOnlyArray<number>): number[] {
+}
+
+function foo(...numbers: number[]): number[] {
+                         ~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+
+
+// Function Expressions
+
+const foo = function(...numbers: ReadOnlyArray<number>): ReadOnlyArray<number> {
+}
+
+const foo = function(...numbers: Array<number>): ReadOnlyArray<number> {
+                                 ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+const foo = function(...numbers: ReadOnlyArray<number>): Array<number> {
+}
+
+const foo = function(...numbers: Array<number>): Array<number> {
+                                 ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+const foo = function(...numbers: ReadOnlyArray<number>): number[] {
+}
+
+const foo = function(...numbers: number[]): number[] {
+                                 ~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+
+
+// Arrow Functions
+
+const foo = (...numbers: ReadOnlyArray<number>): ReadOnlyArray<number> =>  {
+}
+
+const foo = (...numbers: Array<number>): ReadOnlyArray<number> =>  {
+                         ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+const foo = (...numbers: ReadOnlyArray<number>): Array<number> =>  {
+}
+
+const foo = (...numbers: Array<number>): Array<number> =>  {
+                         ~~~~~~~~~~~~~ [Only ReadonlyArray allowed.]
+}
+
+const foo = (...numbers: ReadOnlyArray<number>): number[] => {
+}
+
+const foo = (...numbers: number[]): number[] => {
+                         ~~~~~~~~ [Only ReadonlyArray allowed.]
+}

--- a/test/rules/readonly-array/ignore-return-type/tslint.json
+++ b/test/rules/readonly-array/ignore-return-type/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "readonly-array": [true, "ignore-return-type"]
+  }
+}


### PR DESCRIPTION
Fixes: #82 