### PR TITLE
update `no-throw` to not allow Promise.reject()

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,14 +451,14 @@ function divide(x: number, y: number): number | Error {
 }
 ```
 
-Or in the case of an async function, a rejected promise should be returned:
+And likewise for async functions:
 
 ```typescript
-async function divide(x: Promise<number>, y: Promise<number>): Promise<number> {
+async function divide(x: Promise<number>, y: Promise<number>): Promise<number | Error> {
   const [xv, yv] = await Promise.all([x, y]);
 
   return yv === 0
-    ? Promise.reject(new Error("Cannot divide by zero."))
+    ? new Error("Cannot divide by zero.")
     : xv / yv;
 }
 ```

--- a/src/noThrowRule.ts
+++ b/src/noThrowRule.ts
@@ -19,7 +19,16 @@ function checkNode(
   node: ts.Node,
   _ctx: Lint.WalkContext<Options>
 ): CheckNodeResult {
-  return utils.isThrowStatement(node)
-    ? { invalidNodes: [createInvalidNode(node, [])] }
-    : { invalidNodes: [] };
+  if (utils.isThrowStatement(node)) {
+    return { invalidNodes: [createInvalidNode(node, [])] };
+  }
+  if (
+    ts.isPropertyAccessExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "Promise" &&
+    node.name.text === "reject"
+  ) {
+    return { invalidNodes: [createInvalidNode(node, [])] };
+  }
+  return { invalidNodes: [] };
 }

--- a/test/rules/no-throw/default/test.ts.lint
+++ b/test/rules/no-throw/default/test.ts.lint
@@ -9,9 +9,6 @@ throw error;
 throw new Error();
 ~~~~~~~~~~~~~~~~~~ [failure]
 
-throw new Error();
-~~~~~~~~~~~~~~~~~~ [failure]
-
 function foo(): Promise<number> {
     if (Math.random() > 0.5) {
         return Promise.reject(new Error("bar"))

--- a/test/rules/no-throw/default/test.ts.lint
+++ b/test/rules/no-throw/default/test.ts.lint
@@ -9,4 +9,22 @@ throw error;
 throw new Error();
 ~~~~~~~~~~~~~~~~~~ [failure]
 
+throw new Error();
+~~~~~~~~~~~~~~~~~~ [failure]
+
+function foo(): Promise<number> {
+    if (Math.random() > 0.5) {
+        return Promise.reject(new Error("bar"))
+               ~~~~~~~~~~~~~~ [failure]
+    }
+    return Promise.resolve(10)
+}
+
+function bar(): Promise<number | Error> {
+    if (Math.random() > 0.5) {
+        return Promise.resolve(new Error("foo"))
+    }
+    return Promise.resolve(10)
+}
+
 [failure]: Unexpected throw, throwing exceptions is not functional.


### PR DESCRIPTION
We currently ban `throw` inside async functions and `Promise.reject()`
is another form of async throw.

rel: https://github.com/jonaskello/tslint-immutable/issues/115