### PR TITLE
Move the rejected promises part of no-throw to new rule no-reject

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,16 +451,15 @@ function divide(x: number, y: number): number | Error {
 }
 ```
 
-And likewise for async functions:
+Or in the case of an async function, a rejected promise should be returned:
 
 ```typescript
-async function divide(
-  x: Promise<number>,
-  y: Promise<number>
-): Promise<number | Error> {
+async function divide(x: Promise<number>, y: Promise<number>): Promise<number> {
   const [xv, yv] = await Promise.all([x, y]);
 
-  return yv === 0 ? new Error("Cannot divide by zero.") : xv / yv;
+  return yv === 0
+    ? Promise.reject(new Error("Cannot divide by zero."))
+    : xv / yv;
 }
 ```
 
@@ -625,6 +624,8 @@ While working on the code you can run `yarn test:work`. This script also builds 
 Please review the [tslint performance tips](https://palantir.github.io/tslint/develop/custom-rules/performance-tips.html) in order to write rules that run efficiently at run-time. For example, note that using `SyntaxWalker` or any subclass thereof like `RuleWalker` is inefficient. Note that tslint requires the use of `class` as an entrypoint, but you can make a very small class that inherits from `AbstractRule` which directly calls `this.applyWithFunction` and from there you can switch to using a more functional programming style.
 
 In order to know which AST nodes are created for a snippet of typescript code you can use [ast explorer](https://astexplorer.net/).
+
+To release a new package version run `yarn publish:patch`, `yarn publish:minor`, or `yarn publish:major`.
 
 ## How to publish
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In addition to immutable rules this project also contains a few rules for enforc
   * [no-loop-statement](#no-loop-statement)
   * [no-throw](#no-throw)
   * [no-try](#no-try)
+  * [no-reject](#no-reject)
 * [Recommended built-in rules](#recommended-built-in-rules)
 
 ## Immutability rules
@@ -451,7 +452,7 @@ function divide(x: number, y: number): number | Error {
 }
 ```
 
-Or in the case of an async function, a rejected promise should be returned:
+Or in the case of an async function, a rejected promise should be returned.
 
 ```typescript
 async function divide(x: Promise<number>, y: Promise<number>): Promise<number> {
@@ -466,6 +467,27 @@ async function divide(x: Promise<number>, y: Promise<number>): Promise<number> {
 ### no-try
 
 Try statements are not part of functional programming. See [no-throw](#no-throw) for more information.
+
+### no-reject
+
+You can view a `Promise` as a result object with built-in error (something like `{ value: number } | { error: Error }`) in which case a rejected `Promise` can be viewed a returned result and thus fits with functional programming. You can also view a rejected promise as something similar to an exception and as such something that does not fit with functional programming. If your view is the latter you can use the `no-reject` rule to disallow rejected promises.
+
+```typescript
+async function divide(
+  x: Promise<number>,
+  y: Promise<number>
+): Promise<number | Error> {
+  const [xv, yv] = await Promise.all([x, y]);
+
+  // Rejecting the promise is not allowed so resolve to an Error instead
+
+  // return yv === 0
+  //   ? Promise.reject(new Error("Cannot divide by zero."))
+  //   : xv / yv;
+
+  return yv === 0 ? new Error("Cannot divide by zero.") : xv / yv;
+}
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -647,8 +647,6 @@ Please review the [tslint performance tips](https://palantir.github.io/tslint/de
 
 In order to know which AST nodes are created for a snippet of typescript code you can use [ast explorer](https://astexplorer.net/).
 
-To release a new package version run `yarn publish:patch`, `yarn publish:minor`, or `yarn publish:major`.
-
 ## How to publish
 
 ```

--- a/src/noRejectRule.ts
+++ b/src/noRejectRule.ts
@@ -1,0 +1,30 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+import {
+  createInvalidNode,
+  CheckNodeResult,
+  createCheckNodeRule
+} from "./shared/check-node";
+
+type Options = {};
+
+// tslint:disable-next-line:variable-name
+export const Rule = createCheckNodeRule(
+  checkNode,
+  "Unexpected reject, return an error instead."
+);
+
+function checkNode(
+  node: ts.Node,
+  _ctx: Lint.WalkContext<Options>
+): CheckNodeResult {
+  if (
+    ts.isPropertyAccessExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "Promise" &&
+    node.name.text === "reject"
+  ) {
+    return { invalidNodes: [createInvalidNode(node, [])] };
+  }
+  return { invalidNodes: [] };
+}

--- a/src/noThrowRule.ts
+++ b/src/noThrowRule.ts
@@ -19,16 +19,7 @@ function checkNode(
   node: ts.Node,
   _ctx: Lint.WalkContext<Options>
 ): CheckNodeResult {
-  if (utils.isThrowStatement(node)) {
-    return { invalidNodes: [createInvalidNode(node, [])] };
-  }
-  if (
-    ts.isPropertyAccessExpression(node) &&
-    ts.isIdentifier(node.expression) &&
-    node.expression.text === "Promise" &&
-    node.name.text === "reject"
-  ) {
-    return { invalidNodes: [createInvalidNode(node, [])] };
-  }
-  return { invalidNodes: [] };
+  return utils.isThrowStatement(node)
+    ? { invalidNodes: [createInvalidNode(node, [])] }
+    : { invalidNodes: [] };
 }

--- a/test/rules/no-reject/default/test.ts.lint
+++ b/test/rules/no-reject/default/test.ts.lint
@@ -1,0 +1,18 @@
+const error = new Error();
+
+function foo(): Promise<number> {
+    if (Math.random() > 0.5) {
+        return Promise.reject(new Error("bar"))
+               ~~~~~~~~~~~~~~ [failure]
+    }
+    return Promise.resolve(10)
+}
+
+function bar(): Promise<number | Error> {
+    if (Math.random() > 0.5) {
+        return Promise.resolve(new Error("foo"))
+    }
+    return Promise.resolve(10)
+}
+
+[failure]: Unexpected reject, return an error instead.

--- a/test/rules/no-reject/default/tslint.json
+++ b/test/rules/no-reject/default/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../../rules"],
+  "rules": {
+    "no-reject": true
+  }
+}

--- a/test/rules/no-throw/default/test.ts.lint
+++ b/test/rules/no-throw/default/test.ts.lint
@@ -9,19 +9,4 @@ throw error;
 throw new Error();
 ~~~~~~~~~~~~~~~~~~ [failure]
 
-function foo(): Promise<number> {
-    if (Math.random() > 0.5) {
-        return Promise.reject(new Error("bar"))
-               ~~~~~~~~~~~~~~ [failure]
-    }
-    return Promise.resolve(10)
-}
-
-function bar(): Promise<number | Error> {
-    if (Math.random() > 0.5) {
-        return Promise.resolve(new Error("foo"))
-    }
-    return Promise.resolve(10)
-}
-
 [failure]: Unexpected throw, throwing exceptions is not functional.


### PR DESCRIPTION
This bascially moves #116 to a new rule called `no-reject`. See [this comment](https://github.com/jonaskello/tslint-immutable/issues/115#issuecomment-464891164) for the background.

Fixes #115.