### PR TITLE
Fixes #124 - Implemented "checkIsReturnTypeOrNestedWithIn" more genetically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Fixed rule readonly-array with option ignore-return-type not checking within union, intersection and conditional types. This fix should now catch all return types that contain a nested array. See [#124](https://github.com/jonaskello/tslint-immutable/issues/124). See PR [#125](https://github.com/jonaskello/tslint-immutable/pull/125)
+
 ## [v5.3.2] - 2019-03-07
 
 ### Fixed

--- a/src/readonlyArrayRule.ts
+++ b/src/readonlyArrayRule.ts
@@ -135,24 +135,12 @@ export function checkImplicitType(
   return [];
 }
 
-function checkIsReturnTypeOrNestedWithIn(
-  node: ts.TypeReferenceNode | ts.ArrayTypeNode
-): boolean {
-  const getRootTypeReferenceNode = (
-    typeNode: ts.TypeReferenceNode | ts.ArrayTypeNode | ts.TupleTypeNode
-  ): ts.TypeReferenceNode | ts.ArrayTypeNode | ts.TupleTypeNode =>
-    utils.isTypeReferenceNode(typeNode.parent) ||
-    utils.isTupleTypeNode(typeNode.parent)
-      ? getRootTypeReferenceNode(typeNode.parent)
-      : typeNode;
-
-  const rootTypeReferenceNode = getRootTypeReferenceNode(node);
-
-  return (
-    rootTypeReferenceNode.parent &&
-    isFunctionLikeDeclaration(rootTypeReferenceNode.parent) &&
-    rootTypeReferenceNode === rootTypeReferenceNode.parent.type
-  );
+function checkIsReturnTypeOrNestedWithIn(node: ts.Node): boolean {
+  return node.parent
+    ? isFunctionLikeDeclaration(node.parent) && node === node.parent.type
+      ? true
+      : checkIsReturnTypeOrNestedWithIn(node.parent)
+    : false;
 }
 
 function isUntypedAndHasArrayLiteralExpressionInitializer(

--- a/test/rules/readonly-array/ignore-return-type/function.ts.lint
+++ b/test/rules/readonly-array/ignore-return-type/function.ts.lint
@@ -137,3 +137,21 @@ function foo(...numbers: ReadOnlyArray<number>): [number, Array<number>, number]
 
 function foo(...numbers: ReadOnlyArray<number>): [number, number[], number] {
 }
+
+
+// Union Types
+
+function foo(...numbers: ReadOnlyArray<number>): { a: Array<number> } | { b: string[] } {
+}
+
+
+// Intersection Types
+
+function foo(...numbers: ReadOnlyArray<number>): { a: Array<number> } & { b: string[] } {
+}
+
+
+// Conditional Types
+
+function foo<T>(x: T): T extends Array<number> ? string : number[] {
+}


### PR DESCRIPTION
Fixes #124 

This method should now find nested types no matter how deeply nested or what they are nested within.