### PR TITLE
Fixes #112 - Object.assign mutation is no longer allowed on identifiers and property access expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* no-object-mutation rule now disallows Object.assign mutation on identifiers. See [#112](https://github.com/jonaskello/tslint-immutable/issues/112). See PR [#127](https://github.com/jonaskello/tslint-immutable/pull/127)
+
 ## [v5.3.3] - 2019-03-12
 
 * Fixed rule readonly-array with option ignore-return-type not checking within union, intersection and conditional types. This fix should now catch all return types that contain a nested array. See [#124](https://github.com/jonaskello/tslint-immutable/issues/124). See PR [#125](https://github.com/jonaskello/tslint-immutable/pull/125)

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ No
 
 ### no-object-mutation
 
+[![Type Info Required][type-info-badge]][type-info-url]
+
 This rule prohibits syntax that mutates existing objects via assignment to or deletion of their properties. While requiring the `readonly` modifier forces declared types to be immutable, it won't stop assignment into or modification of untyped objects or external types declared under different rules. Forbidding forms like `a.b = 'c'` is one way to plug this hole. Inspired by the no-mutation rule of [eslint-plugin-immutable](https://github.com/jhusain/eslint-plugin-immutable).
 
 ```typescript
@@ -279,6 +281,7 @@ const x = { a: 1 };
 x.foo = "bar"; // <- Modifying properties of existing object not allowed.
 x.a += 1; // <- Modifying properties of existing object not allowed.
 delete x.a; // <- Modifying properties of existing object not allowed.
+Object.assign(x, { b: 2 }); // <- Modifying properties of existing object not allowed.
 ```
 
 #### Has Fixer

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -90,7 +90,7 @@ function checkNode(
     invalidNodes = [...invalidNodes, createInvalidNode(node, [])];
   }
 
-  // No Object.assign on non-new.
+  // No Object.assign on identifiers.
   if (
     utils.isCallExpression(node) &&
     utils.isPropertyAccessExpression(node.expression) &&
@@ -102,6 +102,7 @@ function checkNode(
       node.arguments[0].getText(node.arguments[0].getSourceFile()),
       ctx.options.ignorePrefix
     ) &&
+    // Do type checking as late as possible as it is expensive.
     isObjectConstructorType(
       checker.getTypeAtLocation(node.expression.expression)
     )

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -98,6 +98,10 @@ function checkNode(
     node.expression.name.text === "assign" &&
     node.arguments.length >= 2 &&
     utils.isIdentifier(node.arguments[0]) &&
+    !Ignore.isIgnoredPrefix(
+      node.arguments[0].getText(node.arguments[0].getSourceFile()),
+      ctx.options.ignorePrefix
+    ) &&
     isObjectConstructorType(
       checker.getTypeAtLocation(node.expression.expression)
     )

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -97,7 +97,8 @@ function checkNode(
     utils.isIdentifier(node.expression.name) &&
     node.expression.name.text === "assign" &&
     node.arguments.length >= 2 &&
-    utils.isIdentifier(node.arguments[0]) &&
+    (utils.isIdentifier(node.arguments[0]) ||
+      utils.isPropertyAccessExpression(node.arguments[0])) &&
     !Ignore.isIgnoredPrefix(
       node.arguments[0].getText(node.arguments[0].getSourceFile()),
       ctx.options.ignorePrefix

--- a/src/noObjectMutationRule.ts
+++ b/src/noObjectMutationRule.ts
@@ -5,7 +5,7 @@ import { isAssignmentKind } from "tsutils/util";
 import {
   createInvalidNode,
   CheckNodeResult,
-  createCheckNodeRule,
+  createCheckNodeTypedRule,
   InvalidNode
 } from "./shared/check-node";
 import * as Ignore from "./shared/ignore";
@@ -14,10 +14,16 @@ import { isAccessExpression } from "./shared/typeguard";
 type Options = Ignore.IgnorePrefixOption;
 
 // tslint:disable-next-line:variable-name
-export const Rule = createCheckNodeRule(
+export const Rule = createCheckNodeTypedRule(
   checkNode,
   "Modifying properties of existing object not allowed."
 );
+
+type ObjectConstructorType = ts.Type & {
+  symbol: {
+    name: "ObjectConstructor";
+  };
+};
 
 const forbidUnaryOps: ReadonlyArray<ts.SyntaxKind> = [
   ts.SyntaxKind.PlusPlusToken,
@@ -26,7 +32,8 @@ const forbidUnaryOps: ReadonlyArray<ts.SyntaxKind> = [
 
 function checkNode(
   node: ts.Node,
-  ctx: Lint.WalkContext<Options>
+  ctx: Lint.WalkContext<Options>,
+  checker: ts.TypeChecker
 ): CheckNodeResult {
   let invalidNodes: Array<InvalidNode> = [];
 
@@ -83,6 +90,21 @@ function checkNode(
     invalidNodes = [...invalidNodes, createInvalidNode(node, [])];
   }
 
+  // No Object.assign on non-new.
+  if (
+    utils.isCallExpression(node) &&
+    utils.isPropertyAccessExpression(node.expression) &&
+    utils.isIdentifier(node.expression.name) &&
+    node.expression.name.text === "assign" &&
+    node.arguments.length >= 2 &&
+    utils.isIdentifier(node.arguments[0]) &&
+    isObjectConstructorType(
+      checker.getTypeAtLocation(node.expression.expression)
+    )
+  ) {
+    invalidNodes = [...invalidNodes, createInvalidNode(node, [])];
+  }
+
   return { invalidNodes };
 }
 
@@ -95,4 +117,10 @@ function inConstructor(nodeIn: ts.Node): boolean {
     node = node.parent;
   }
   return false;
+}
+
+export function isObjectConstructorType(
+  type: ts.Type
+): type is ObjectConstructorType {
+  return Boolean(type.symbol && type.symbol.name === "ObjectConstructor");
 }

--- a/test/rules/no-object-mutation/default/test.ts.lint
+++ b/test/rules/no-object-mutation/default/test.ts.lint
@@ -93,4 +93,19 @@ class Foo {
     }
 }
 
+// Disallow Object.assign() on non-new objects.
+
+const value = { msg1: 'hello' };
+
+const foo = Object.assign(value, { msg2: 'world' });
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+// Allow Object.assign() on new objects.
+
+const bar = (a, b, c) => ({a, b, c});
+
+const foo = Object.assign({}, { msg: 'hello world' });
+const foo = Object.assign({ ...value }, { msg2: 'world' });
+const foo = Object.assign(bar(1, 2, 3), { d: 4 });
+
 [failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/default/test.ts.lint
+++ b/test/rules/no-object-mutation/default/test.ts.lint
@@ -95,10 +95,13 @@ class Foo {
 
 // Disallow Object.assign() on identifiers.
 
-const value = { msg1: 'hello' };
+const value = { msg1: 'hello', obj: { a: 1, b: 2}, func: () => {} };
 
 const foo = Object.assign(value, { msg2: 'world' });
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+const foo = Object.assign(value.obj, { msg2: 'world' });
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
 
 // Allow Object.assign() on non identifiers
 
@@ -107,5 +110,6 @@ const bar = (a, b, c) => ({a, b, c});
 const foo = Object.assign({}, { msg: 'hello world' });
 const foo = Object.assign({ ...value }, { msg2: 'world' });
 const foo = Object.assign(bar(1, 2, 3), { d: 4 });
+const foo = Object.assign(value.func(), { d: 4 });
 
 [failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/default/test.ts.lint
+++ b/test/rules/no-object-mutation/default/test.ts.lint
@@ -93,14 +93,14 @@ class Foo {
     }
 }
 
-// Disallow Object.assign() on non-new objects.
+// Disallow Object.assign() on identifiers.
 
 const value = { msg1: 'hello' };
 
 const foo = Object.assign(value, { msg2: 'world' });
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
 
-// Allow Object.assign() on new objects.
+// Allow Object.assign() on non identifiers
 
 const bar = (a, b, c) => ({a, b, c});
 

--- a/test/rules/no-object-mutation/default/tsconfig.json
+++ b/test/rules/no-object-mutation/default/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    // Coding style
+    "forceConsistentCasingInFileNames": true,
+    "newLine": "LF",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "lib": ["es2015", "dom"]
+  }
+}

--- a/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
+++ b/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
@@ -30,7 +30,7 @@ mutableY.a++;
 
 ++mutableY.a;
 
-// Disallow Object.assign() on non-new objects.
+// Disallow Object.assign() on identifiers.
 
 const value = { msg1: 'hello' };
 const mutableValue = value;

--- a/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
+++ b/test/rules/no-object-mutation/ignore-prefix/test.ts.lint
@@ -30,4 +30,14 @@ mutableY.a++;
 
 ++mutableY.a;
 
+// Disallow Object.assign() on non-new objects.
+
+const value = { msg1: 'hello' };
+const mutableValue = value;
+
+const foo = Object.assign(value, { msg2: 'world' });
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure]
+
+const foo = Object.assign(mutableValue, { msg2: 'world' });
+
 [failure]: Modifying properties of existing object not allowed.

--- a/test/rules/no-object-mutation/ignore-prefix/tsconfig.json
+++ b/test/rules/no-object-mutation/ignore-prefix/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    // Coding style
+    "forceConsistentCasingInFileNames": true,
+    "newLine": "LF",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "lib": ["es2015", "dom"]
+  }
+}


### PR DESCRIPTION
Fixes #112

This PR makes it so `Object.assign` is banned when used with an identifier or a property access expressions as the first parameter.  
For example, this would no longer be allowed:

```ts
const value = { msg1: "hello" };
const foo = Object.assign(value, { msg2: "world" });
```

But these are allowed:

```ts
const foo = Object.assign({}, { msg: "hello world" });
const foo = Object.assign({}, value, { msg2: "world" });
const foo = Object.assign({ ...value }, { msg2: "world" });
```

This is allowed too:

```ts
const bar = (a, b, c) => ({a, b, c});
const foo = Object.assign(bar(1, 2, 3), { d: 4 });
```